### PR TITLE
Continue on 0x80070490 error - caused by third-party driver

### DIFF
--- a/DriverUpdater/DismProvider.cs
+++ b/DriverUpdater/DismProvider.cs
@@ -173,9 +173,16 @@ namespace DriverUpdater
                 if ((ntStatus & 0x80000000) != 0)
                 {
                     Logging.Log("");
-                    Logging.Log($"RemoveOfflineDriver: ntStatus=0x{ntStatus:X8}, driver={driver}", Logging.LoggingLevel.Error);
-
-                    return false;
+                    
+                    if (ntStatus == 0x80070490)
+                    {
+                        Logging.Log($"RemoveOfflineDriver: ntStatus=0x{ntStatus:X8}, driver={driver}", Logging.LoggingLevel.Warning);
+                    }
+                    else
+                    {
+                        Logging.Log($"RemoveOfflineDriver: ntStatus=0x{ntStatus:X8}, driver={driver}", Logging.LoggingLevel.Error);
+                        return false;
+                    }
                 }
             }
             Logging.ShowProgress(existingOEMDrivers.Length, existingOEMDrivers.Length, startTime, false);


### PR DESCRIPTION
When you install MPLAB X IDE, it will install some USB drivers, and then DriverUpdater fails when uninstalling drivers, leaving you with an unusable Windows installation. Maybe in some future update it will be good to remove just SurfaceDUO drivers...